### PR TITLE
T4801 - Adicionar Tradução Form.io Partner / Data API e Habilitar a Instação

### DIFF
--- a/formio/controllers/main.py
+++ b/formio/controllers/main.py
@@ -55,7 +55,6 @@ class FormioController(http.Controller):
     def builder_schema(self, builder_id, **kwargs):
         if not request.env.user.has_group('formio.group_formio_admin'):
             return
-
         builder = request.env['formio.builder'].browse(builder_id)
         if builder and builder.schema:
             return builder.schema

--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -194,12 +194,12 @@ class Form(models.Model):
 
             # public
             form.public_access = form._public_access()
-
+            
     def _public_access(self):
         if self.public_share and self.public_access_date_from:
             now = fields.Datetime.now()
             expire_on = self.public_access_date_from + self._interval_types[self.public_access_interval_type](self.public_access_interval_number)
-
+            
             if self.public_access_interval_number == 0:
                 return False
             elif self.public_access_date_from > now:
@@ -340,7 +340,7 @@ class Form(models.Model):
         self.public_share = self.builder_id.public
         self.public_access_interval_number = self.builder_id.public_access_interval_number
         self.public_access_interval_type = self.builder_id.public_access_interval_type
-
+        
         if self.builder_id.public:
             self.public_access_date_from = fields.Datetime.now()
 

--- a/formio/views/formio_builder_views.xml
+++ b/formio/views/formio_builder_views.xml
@@ -67,7 +67,7 @@ See LICENSE file for full licensing details. -->
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_formio" type="object" string="Form Builder"
                                 groups="formio.group_formio_admin"
-                                class="oe_stat_button" icon="fa-rocket"/>
+                                class="oe_stat_button" icon="fa-file-text-o"/>
                     </div>
                     <label for="title" class="oe_edit_only"/>
                     <h1><field name="title" placeholder="Insert a meaningful title here"/></h1>

--- a/formio/views/formio_form_templates.xml
+++ b/formio/views/formio_form_templates.xml
@@ -67,13 +67,15 @@ See LICENSE file for full licensing details. -->
                     <h3 t-if="builder.show_form_title" class="formio_form_title"><span name="title" t-esc="builder.title"/></h3>
                 </t>
 
-                <!-- <t t-if="languages">
+                <!-- Comentado para não mostrar nos Formulários
+                <t t-if="languages">
                     <div class="formio_languages">
                         <t t-foreach="languages" t-as="lang">
                             <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.iso_code }}')"><span t-field="lang.name"/></button>
                         </t>
                     </div>
                 </t> -->
+                
                 <div class="formio_form_embed_container">
                     <div id="formio_form"></div>
                 </div>

--- a/formio/views/formio_form_views.xml
+++ b/formio/views/formio_form_views.xml
@@ -151,7 +151,7 @@ See LICENSE file for full licensing details. -->
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_formio" type="object" string="Form"
-                                class="oe_stat_button" icon="fa-rocket" aria-label="Form"/>
+                                class="oe_stat_button" icon="fa-file-text-o" aria-label="Form"/>
                         <button name="action_open_res_act_window" type="object" string="Source Link"
                                 attrs="{'invisible': ['|', ('res_id', '=', False), ('res_id', '=', 0)]}"
                                 class="oe_stat_button" icon="fa-link" aria-label="Resource">
@@ -271,16 +271,16 @@ See LICENSE file for full licensing details. -->
         <field name="view_mode">tree,kanban,form,formio_form</field>
     </record>
 
-    <record id="action_formio_form_view_kanban" model="ir.actions.act_window.view">
-        <field name="sequence" eval="0"/>
-        <field name="view_mode">kanban</field>
-        <field name="view_id" ref="formio.view_formio_form_kanban"/>
-        <field name="act_window_id" ref="action_formio_form"/>
-    </record>
     <record id="action_formio_form_view_tree" model="ir.actions.act_window.view">
-        <field name="sequence" eval="1"/>
+        <field name="sequence" eval="0"/>
         <field name="view_mode">tree</field>
         <field name="view_id" ref="formio.view_formio_form_tree"/>
+        <field name="act_window_id" ref="action_formio_form"/>
+    </record>
+    <record id="action_formio_form_view_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="formio.view_formio_form_kanban"/>
         <field name="act_window_id" ref="action_formio_form"/>
     </record>
     <record id="action_formio_form_view_form" model="ir.actions.act_window.view">

--- a/formio/views/formio_public_templates.xml
+++ b/formio/views/formio_public_templates.xml
@@ -43,7 +43,7 @@ See LICENSE file for full licensing details. -->
                                 <span t-attf-class="badge mb-1 badge-pill badge-success">Estado: <strong><t t-esc="form.display_state"/></strong></span>
                             </t>
                             <t t-elif="form.state == 'CANCEL'">
-                                <span t-attf-class="badge mb-1 badge-pill badge-dark">State: <strong><t t-esc="form.display_state"/></strong></span>
+                                <span t-attf-class="badge mb-1 badge-pill badge-dark">Estado: <strong><t t-esc="form.display_state"/></strong></span>
                             </t>
                             <t t-else="">
                                 <span t-attf-class="badge mb-1 badge-pill badge-light">Estado: <strong><t t-esc="form.display_state"/></strong></span>
@@ -51,7 +51,8 @@ See LICENSE file for full licensing details. -->
                         </li>
                     </ul>
                 </div>
-                <!-- <t t-if="languages">
+                <!-- Comentado para não mostrar no Formulário
+                <t t-if="languages">
                     <div class="formio_languages">
                         <t t-foreach="languages" t-as="lang">
                             <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.iso_code }}')"><span t-field="lang.name"/></button>
@@ -92,7 +93,8 @@ See LICENSE file for full licensing details. -->
                     <h3 t-if="builder.show_form_title" class="formio_form_title"><span name="title" t-esc="builder.title"/></h3>
                 </t>
 
-                <!-- <t t-if="languages">
+                <!-- Comentado para não mostrar no Formulário
+                <t t-if="languages">
                     <div class="formio_languages">
                         <t t-foreach="languages" t-as="lang">
                             <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.iso_code }}')"><span t-field="lang.name"/></button>

--- a/formio_data_api/__manifest__.py
+++ b/formio_data_api/__manifest__.py
@@ -16,7 +16,7 @@
         'python': ['formiodata'],
     },
     'application': False,
-    'installable': False,
+    'installable': True,
     'images': [
         'static/description/banner.png',
     ],

--- a/formio_data_api/i18n/pt_BR.po
+++ b/formio_data_api/i18n/pt_BR.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* formio_data_api
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-21 12:52+0000\n"
+"PO-Revision-Date: 2020-09-21 12:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: formio_data_api
+#: model:ir.model,name:formio_data_api.model_formio_form
+msgid "Formio Form"
+msgstr "Formulário Form.io"

--- a/formio_partner/i18n/pt_BR.po
+++ b/formio_partner/i18n/pt_BR.po
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* formio_partner
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-21 12:37+0000\n"
+"PO-Revision-Date: 2020-09-21 12:37+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: formio_partner
+#: model:ir.model.fields,field_description:formio_partner.field_res_partner__formio_forms
+#: model:ir.model.fields,field_description:formio_partner.field_res_users__formio_forms
+msgid "Form.io Forms"
+msgstr "Formulários Form.io"
+
+#. module: formio_partner
+#: model:ir.model,name:formio_partner.model_formio_form
+msgid "Formio Form"
+msgstr "Formulário Form.io"
+
+#. module: formio_partner
+#: model:ir.model.fields,field_description:formio_partner.field_res_partner__formio_forms_count
+#: model:ir.model.fields,field_description:formio_partner.field_res_users__formio_forms_count
+msgid "Formio Forms Count"
+msgstr "Quantidade"
+
+#. module: formio_partner
+#: model:ir.model.fields,field_description:formio_partner.field_res_partner__formio_this_model_id
+#: model:ir.model.fields,field_description:formio_partner.field_res_users__formio_this_model_id
+msgid "Formio This Model"
+msgstr "Este Modelo"
+
+#. module: formio_partner
+#: model_terms:ir.ui.view,arch_db:formio_partner.view_partner_form_formio_partner
+msgid "Forms"
+msgstr "Formulários"
+
+#. module: formio_partner
+#: model:ir.model,name:formio_partner.model_res_partner
+#: model:ir.model.fields,field_description:formio_partner.field_formio_form__base_res_partner_id
+msgid "Partner"
+msgstr "Parceiro"
+

--- a/formio_report_qweb/__manifest__.py
+++ b/formio_report_qweb/__manifest__.py
@@ -19,7 +19,7 @@
         'views/formio_builder_report_views.xml'
     ],
     'application': True,
-    'installable': False,
+    'installable': True,
     'images': [
         'static/description/banner.png',
     ],

--- a/formio_report_qweb/i18n/pt_BR.po
+++ b/formio_report_qweb/i18n/pt_BR.po
@@ -1,0 +1,144 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* formio_report_qweb
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-21 12:52+0000\n"
+"PO-Revision-Date: 2020-09-21 12:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.component_not_implemented
+msgid "<small>WARNING: component not implemented (showing raw data)</small>"
+msgstr "<small>AVISO: componente não implementado (mostrando dados brutos)</small>"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.report_formio_form_template
+msgid "<strong>Atribuído a:</strong>"
+msgstr ""
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.report_formio_form_template
+msgid "<strong>Date:</strong>"
+msgstr "<strong>Data:</strong>"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.report_formio_form_template
+msgid "<strong>ID:</strong>"
+msgstr ""
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.report_formio_form_template
+msgid "<strong>Respondido por:</strong>"
+msgstr ""
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__display_name
+msgid "Display Name"
+msgstr "Nome exibido"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.report_formio_form_template
+msgid "Estado:"
+msgstr ""
+
+#. module: formio_report_qweb
+#: model:ir.actions.report,name:formio_report_qweb.action_report_formio_form_assigned_user
+msgid "Form (Assigned user preferences)"
+msgstr "Formulário (preferências atribuídas ao usuário)"
+
+#. module: formio_report_qweb
+#: model:ir.actions.report,name:formio_report_qweb.action_report_formio_form
+msgid "Form (My preferences)"
+msgstr "Formulário (minhas preferências)"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__builder_id
+msgid "Form Builder"
+msgstr "Construtor de Formulários"
+
+#. module: formio_report_qweb
+#: model:ir.model,name:formio_report_qweb.model_formio_builder
+msgid "Formio Builder"
+msgstr "Construtor Form.io"
+
+#. module: formio_report_qweb
+#: model:ir.model,name:formio_report_qweb.model_formio_builder_report
+#: model:ir.model.fields,field_description:formio_report_qweb.field_ir_actions_report__formio_builder_report_ids
+msgid "Formio Builder Reports"
+msgstr "Relatórios Formio Builder"
+
+#. module: formio_report_qweb
+#: model:ir.model,name:formio_report_qweb.model_formio_form
+msgid "Formio Form"
+msgstr "Formulário Form.io"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__id
+msgid "ID"
+msgstr ""
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report____last_update
+msgid "Last Modified on"
+msgstr "Última modificação em"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__write_date
+msgid "Last Updated on"
+msgstr "Última atualização em"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__ir_actions_report_id
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.view_formio_builder_form_inherit
+msgid "Report"
+msgstr "Relatório"
+
+#. module: formio_report_qweb
+#: model:ir.model,name:formio_report_qweb.model_ir_actions_report
+msgid "Report Action"
+msgstr "Reportar Ação"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder__report_ids
+msgid "Reports"
+msgstr "Relatórios"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.view_formio_builder_form_inherit
+msgid "Reports Config"
+msgstr "Configuração de Relatórios"
+
+#. module: formio_report_qweb
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.formio_builder_report_form
+msgid "Settings"
+msgstr "Configurações"
+
+#. module: formio_report_qweb
+#: model:ir.model.fields,field_description:formio_report_qweb.field_formio_builder_report__show_components_not_implemented
+#: model_terms:ir.ui.view,arch_db:formio_report_qweb.formio_builder_report_form
+msgid "Show not implemented components"
+msgstr "Mostrar componentes não implementados"

--- a/formio_report_qweb/report/report_formio_form.xml
+++ b/formio_report_qweb/report/report_formio_form.xml
@@ -41,7 +41,7 @@ See LICENSE file for full copyright and licensing details.
                         <strong>Respondido por:</strong> <span t-field="o.submission_partner_name"/>
                     </div>
                     <div t-if="o.submission_data" class="col-4">
-                        <strong>Date:</strong> <span t-field="o.submission_date"/>
+                        <strong>Data:</strong> <span t-field="o.submission_date"/>
                     </div>
                     <div class="col-2">
                         <t t-if="o.state == 'PENDING'">


### PR DESCRIPTION
# Descrição

[IMP] Atualiza tradução pt_br modulo 'formio_partner'
[IMP] Atualiza tradução pt_br modulo 'formio_data_api'
[IMP] Atualiza tradução pt_br modulo 'formio_report_qweb'
[IMP] Habilita modulos 'formio_data_api' e 'formio_report_qweb'
- Habilita modulos para Instalação
- Troca icone dos Botões para Formulário
- Acertos nos Códigos para uso no MultiERP

# Informações adicionais

[T4801](https://multi.multidadosti.com.br/web?#id=5210&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)