### PR TITLE
T4892 - Erro no modulo Formio Partner, causa erro ao alterar o endereço do Parceiro

### DIFF
--- a/formio_partner/models/partner.py
+++ b/formio_partner/models/partner.py
@@ -25,10 +25,11 @@ class ResPartner(models.Model):
         # Simpler to maintain and less risk with extending, than
         # computed field(s) in the formio.form object.
         res = super(ResPartner, self).write(vals)
-        if self.formio_forms:
-            form_vals = self._prepare_write_formio_form_vals(vals)
-            if form_vals:
-                self.formio_forms.write(form_vals)
+        for record in self:
+            if record.formio_forms:
+                form_vals = record._prepare_write_formio_form_vals(vals)
+                if form_vals:
+                    record.formio_forms.write(form_vals)
         return res
 
     def _prepare_write_formio_form_vals(self, vals):


### PR DESCRIPTION
# Descrição

- [BUG] Corrige erro na hora de alterar endereço de um parceiro

# Informações adicionais

- [T4892 ](https://multi.multidadosti.com.br/web?#id=5301&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)