### PR TITLE
T5178 - Liberar o Formio para Vendas

### DIFF
--- a/formio_sale/__manifest__.py
+++ b/formio_sale/__manifest__.py
@@ -18,7 +18,7 @@
         'views/sale_views.xml',
     ],
     'application': True,
-    'installable': False,
+    'installable': True,
     'images': [
         'static/description/banner.gif',
     ],


### PR DESCRIPTION
# Descrição

* [IMP] Habilita instalação do modulo 'formio_sale'

# Informações adicionais

Dados da tarefa: [T5178](https://multi.multidadosti.com.br/web#id=5587&action=323&active_id=61&model=project.task&view_type=form&menu_id=)

PR(s) relacionado(s) (se houver):
