### PR TITLE
T5277 - Erro na Criação do Form de Projeto

### DIFF
--- a/formio_project/models/formio_form.py
+++ b/formio_project/models/formio_form.py
@@ -22,9 +22,8 @@ class Form(models.Model):
             id=res_id,
             model='project.project',
             action=action.id)
-        res_model_name = builder.res_model_id.name
 
-        vals['project_project_id'] = res_id
+        vals['project_id'] = res_id
         vals['res_partner_id'] = project.partner_id.id
         vals['res_act_window_url'] = url
         vals['res_name'] = project.name


### PR DESCRIPTION
# Descrição

[FIX] Corrige erro de campo no modulo 'formio_project'

# Informações adicionais

Dados da tarefa: [T5277](https://multi.multidadosti.com.br/web?debug=#id=5686&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
