### PR TITLE
T5438 - Erro de permissao no runbot da formio

### DIFF
--- a/formio_sale/__manifest__.py
+++ b/formio_sale/__manifest__.py
@@ -12,6 +12,7 @@
     'category': 'Sales',
     'depends': ['sale_management', 'formio', 'formio_data_api'],
     'data': [
+        'security/ir_model_access.xml',
         'data/formio_sale_data.xml',
         'data/formio_demo_data.xml',
         'views/formio_form_views.xml',

--- a/formio_sale/models/sale.py
+++ b/formio_sale/models/sale.py
@@ -25,10 +25,13 @@ class SaleOrder(models.Model):
         # Simpler to maintain and less risk with extending, than
         # computed field(s) in the formio.form object.
         res = super(SaleOrder, self).write(vals)
-        if self.formio_forms:
-            form_vals = self._prepare_write_formio_form_vals(vals)
-            if form_vals:
-                self.formio_forms.write(form_vals)
+
+        for rec in self:
+            if rec.formio_forms:
+                form_vals = rec._prepare_write_formio_form_vals(vals)
+                if form_vals:
+                    rec.formio_forms.write(form_vals)
+
         return res
 
     def _prepare_write_formio_form_vals(self, vals):

--- a/formio_sale/security/ir_model_access.xml
+++ b/formio_sale/security/ir_model_access.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="access_formio_form_sale_salesman" model="ir.model.access">
+            <field name="name">formio.form: Salesman</field>
+            <field name="model_id" ref="formio.model_formio_form"/>
+            <field name="group_id" ref="sales_team.group_sale_salesman"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="0"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_unlink" eval="0"/>
+        </record>
+
+        <record id="access_formio_form_sale_manager" model="ir.model.access">
+            <field name="name">formio.form: Sale Manager</field>
+            <field name="model_id" ref="formio.model_formio_form"/>
+            <field name="group_id" ref="sales_team.group_sale_manager"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
# Descrição

* [IMP] Adiciona regra de acesso para grupos de vendas

A ausência de regras de acesso para os grupos de venda:

* group_sale_salesman
* group_sale_manager

estava causando erros de permissão, conforme exemplo abaixo:

http://multierp-runbot.ddns.net:8069/runbot/build/11173

Este commit adiciona regras de acesso de modo a corrigir os problemas de permissão de leitura.

# Informações adicionais

Dados da tarefa: [T5438](https://multi.multidadosti.com.br/web#id=5847&action=323&active_id=61&model=project.task&view_type=form&menu_id=)
