### PR TITLE
T5613 - Corrigir Relatório Formio que não respeita o Hide Label

### DIFF
--- a/formio/i18n/pt_BR.po
+++ b/formio/i18n/pt_BR.po
@@ -2156,12 +2156,12 @@ msgstr ""
 #: model:ir.model.fields,help:formio.field_formio_builder__formio_version_name
 #: model:ir.model.fields,help:formio.field_formio_version__name
 msgid "formio release/version."
-msgstr ""
+msgstr "Lançamento/Versão do Formio."
 
 #. module: formio
 #: model:ir.model.fields,field_description:formio.field_formio_builder__formio_version_name
 msgid "formio version"
-msgstr ""
+msgstr "Versão Formio"
 
 #. module: formio
 #: model_terms:ir.ui.view,arch_db:formio.res_config_settings_view_form

--- a/formio_report_qweb/report/report_formio_form_components.xml
+++ b/formio_report_qweb/report/report_formio_form_components.xml
@@ -76,7 +76,7 @@ See LICENSE file for full copyright and licensing details.
     </template>
 
     <template id="component_label">
-        <t t-if="nolabel">
+        <t t-if="nolabel or component.hideLabel">
         </t>
         <t t-elif="component.required">
             <t t-raw="component.label"/> *


### PR DESCRIPTION
# Descrição

[IMP] Adiciona verificação 'HideLabal' na impressao modulo 'formio_report_qweb'

# Informações adicionais

Dados da tarefa: [T5613](https://multi.multidadosti.com.br/web?#id=6022&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


