### PR TITLE
T6044 - Criar restrição para acesso a formulário pelo portal

### DIFF
--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -544,7 +544,7 @@ class Form(models.Model):
         }
 
     @api.model
-    def get_form(self, uuid, mode):
+    def get_form(self, uuid, mode, **kwargs):
         """ Verifies access to form and return form or False. """
 
         if not self.env['formio.form'].check_access_rights(mode, False):
@@ -562,7 +562,9 @@ class Form(models.Model):
         # portal user
         if self.env.user.has_group('base.group_portal'):
             form = self.sudo().search([('uuid', '=', uuid)], limit=1)
-            if not form or not form.portal_share or form.user_id.id != self.env.user.id:
+            if not form or not form.portal_share:
+                return False
+            if kwargs.get('check_user', True) and form.user_id.id != self.env.user.id:
                 return False
         return form
 


### PR DESCRIPTION
# Descrição

- [IMP] Altera forma de obter domain 'forms.formio' no Portal
  - Altera forma de obter o domain em funções para facilitar a herança do método no módulo 'br_portal_forms' que altera as regras de acesso dos Forms para os usuários do tipo Portal.

- [IMP] Altera função para facilitar herança no 'br_portal_forms'
  - Foi adicionado uma opção de verificar ou não o usuário que está logado quando ele for do tipo portal, para facilitar a alteração da aplicação de diferentes regras de acesso para usuários do tipo Portal.
  - No módulo 'br_portal_forms' foi adicionado no kwargs na chamada da função o parâmetro "check_user=False" para indicar que a função 'get_form' do 'formio.form' não deve verificar o usuário logado para decidir se irá retornar o form.

- [FIX] Corrige funções do Portal para não dar erro de acesso
  - No runbot as funções do portal do formio estão dando erro de acesso ao tentar realizar searches com o usuário Marc Demo nas models 'formio.form' e 'formio.builder'.

# Informações adicionais

- [T6044](https://multi.multidados.tech/web#id=6453&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/851)
- [core](https://github.com/multidadosti-erp/odoo/pull/154)