### PR TITLE
T6329 - Erro: Ao criar Formulários com assinatura esta dando erro na gravação

### DIFF
--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -257,12 +257,16 @@ class Form(models.Model):
                     else:
                         # último nivel
                         if 'label' in line and 'key' in line:
-                            keys.append(
-                                {'label': line['label'],
-                                 'key': line['key'],
-                                 'value_label': '',
-                                 'value_key': '',
-                                 'values': line['values'] if 'values' in line else ''})
+                            # Assinatura não pode Gravar
+                            isSignature = 'type' in line and line['type'] == 'signature'
+
+                            if not isSignature:
+                                keys.append(
+                                    {'label': line['label'],
+                                    'key': line['key'],
+                                    'value_label': '',
+                                    'value_key': '',
+                                    'values': line['values'] if 'values' in line else ''})
 
         elif type(dct) is dict:
             for key, vals in dct.items():


### PR DESCRIPTION
# Descrição

[FIX] Ajusta Gravação no Banco de dados do Modulo 'form.io'

- Remove a gravação do Campo Assinatura

# Informações adicionais

Dados da tarefa: [T6329](https://multi.multidados.tech/web?#id=6738&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
