### PR TITLE
T8913 - Erro ao tentar retornar itens de locação parcial em contrato

### DIFF
--- a/formio_stock/models/stock_picking.py
+++ b/formio_stock/models/stock_picking.py
@@ -33,10 +33,14 @@ class StockPicking(models.Model):
         # Simpler to maintain and less risk with extending, than
         # computed field(s) in the formio.form object.
         res = super(StockPicking, self).write(vals)
-        if self.formio_forms:
-            form_vals = self._prepare_write_formio_form_vals(vals)
+
+        for stock in self.filtered(lambda r: r.formio_forms):
+
+            form_vals = stock._prepare_write_formio_form_vals(vals)
+
             if form_vals:
-                self.formio_forms.write(form_vals)
+                stock.formio_forms.write(form_vals)
+
         return res
 
     def _prepare_write_formio_form_vals(self, vals):


### PR DESCRIPTION
# Descrição

* Adiciona suporte a recordset no método write  módulo 'formio_stock'

Metodo dispara erro de singleton quando 'self' possui mais de um record.

# Informações adicionais

Dados da tarefa: [T8913](https://multi.multidados.tech/web#id=9322&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

