### PR TITLE
T9833 - Erro no Comercial ao Clicar na Visão Gantt

### DIFF
--- a/formio_sale/models/sale.py
+++ b/formio_sale/models/sale.py
@@ -16,9 +16,9 @@ class SaleOrder(models.Model):
             r.formio_forms_count = len(r.formio_forms)
 
     def _compute_formio_this_model_id(self):
-        self.ensure_one()
         model_id = self.env.ref('sale.model_sale_order').id
-        self.formio_this_model_id = model_id
+        for rec in self:
+            rec.formio_this_model_id = model_id
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
# Descrição

Ajusta Erro 'ValueError: Expected singleton' módulo 'formio_sale'

# Informações adicionais

Dados da tarefa: [T9833](https://multi.multidados.tech/web?#id=10242&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
